### PR TITLE
feat: add basic authentication

### DIFF
--- a/src/ConfluenceClient.php
+++ b/src/ConfluenceClient.php
@@ -5,6 +5,7 @@ namespace CloudPlayDev\ConfluenceClient;
 
 use CloudPlayDev\ConfluenceClient\Api\Content;
 use CloudPlayDev\ConfluenceClient\HttpClient\Builder;
+use CloudPlayDev\ConfluenceClient\HttpClient\Plugin\BasicAuthentication;
 use CloudPlayDev\ConfluenceClient\HttpClient\Plugin\TokenAuthentication;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Common\Plugin\AddHostPlugin;
@@ -32,6 +33,14 @@ class ConfluenceClient
     {
         $this->httpClientBuilder->removePlugin(TokenAuthentication::class);
         $this->httpClientBuilder->addPlugin(new TokenAuthentication($token));
+
+        return $this;
+    }
+
+    public function authenticateBasicAuth(string $username, string $password): ConfluenceClient
+    {
+        $this->httpClientBuilder->removePlugin(BasicAuthentication::class);
+        $this->httpClientBuilder->addPlugin(new BasicAuthentication($username, $password));
 
         return $this;
     }

--- a/src/HttpClient/Plugin/BasicAuthentication.php
+++ b/src/HttpClient/Plugin/BasicAuthentication.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace CloudPlayDev\ConfluenceClient\HttpClient\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+
+final class BasicAuthentication implements Plugin
+{
+    private string $username;
+    private string $password;
+
+    public function __construct(string $username, string $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $auth = base64_encode("$this->username:$this->password");
+        return $next($request->withHeader('Authorization', sprintf('Basic %s', $auth)));
+    }
+}


### PR DESCRIPTION
### What

This pull request allows one to authenticate via basic auth, like so:

`$client = new ConfluenceClient('https://example.atlassian.net');
$client->authenticateBasicAuth('example@example.com', 'password');
`
### Why

Some Confluence instances do not allow users to create API tokens. Adding basic authentication allows users that can't (or prefer not to) use API tokens to use this PHP client.